### PR TITLE
Fix valgrind_macos() function crashing

### DIFF
--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -29,6 +29,7 @@ function valgrind_docker_make () {
 # You must use "./" to specify executable file
 function valgrind_macos ()
 {
+	local i
 	for i in "$@"; do
 		if [[ $i == ./* ]]; then
 			cmd=$(nm -an $i | grep asan)


### PR DESCRIPTION
## Summary
- somewhere in the `zshrc`, `i` might have been used as variable to hold numeric values. 
- for some reason zsh does not have scope for these loops, causing zsh to interpret all value inside i into numeric.
- files starting with './' would be considered as float and caused 'bad floating point constant' error.
- added `local i` to fix the isssue.

## related issue
- https://github.com/sdkman/sdkman-cli/issues/231